### PR TITLE
Add List Command and Enhance Structure Definition in Generate Command

### DIFF
--- a/struct_module/commands/list.py
+++ b/struct_module/commands/list.py
@@ -1,0 +1,21 @@
+from struct_module.commands import Command
+import os
+import yaml
+from struct_module.file_item import FileItem
+
+# List command class
+class ListCommand(Command):
+  def __init__(self, parser):
+    super().__init__(parser)
+    parser.set_defaults(func=self.execute)
+
+  def execute(self, args):
+    self.logger.info(f"Listing available structures")
+    self._list_structures()
+
+  def _list_structures(self):
+    print("Listing available structures")
+    sorted_list = [structure for structure in os.listdir('contribs') if structure.endswith('.yaml')]
+    sorted_list.sort()
+    for structure in sorted_list:
+      print(f" - {structure[:-5]}")

--- a/struct_module/main.py
+++ b/struct_module/main.py
@@ -5,6 +5,7 @@ from struct_module.utils import read_config_file, merge_configs
 from struct_module.commands.generate import GenerateCommand
 from struct_module.commands.info import InfoCommand
 from struct_module.commands.validate import ValidateCommand
+from struct_module.commands.list import ListCommand
 
 
 
@@ -23,6 +24,7 @@ def main():
     InfoCommand(subparsers.add_parser('info', help='Show information about the package'))
     ValidateCommand(subparsers.add_parser('validate', help='Validate the YAML configuration file'))
     GenerateCommand(subparsers.add_parser('generate', help='Generate the project structure'))
+    ListCommand(subparsers.add_parser('list', help='List available structures'))
 
     args = parser.parse_args()
 


### PR DESCRIPTION
#### Overview:
This pull request introduces a new command to list available structures and enhances the `generate` command by improving how structure definitions are handled.

#### Changes:
- **New `list` command**: 
  - Introduces a `ListCommand` that lists available structure definitions from the `contribs` directory.
  - Files ending with `.yaml` are sorted and displayed.
  
- **Enhancements to `generate` command**:
  - Refactors the `yaml_file` argument to `structure_definition`.
  - Adds support for structure definition paths and checks for file existence.
  - A new optional argument `--structures-path` allows specifying a custom directory for structure definitions.

- **Integration in main module**:
  - The new `list` command is added to the main CLI interface.

#### Justification:
These changes improve the usability of the `generate` command by allowing more flexible paths for structure definitions and add a helpful listing command for structure files.

#### Impact:
- The new `list` command provides an easier way for users to find available structure definitions.
- The refactored `generate` command ensures better error handling when structure files are not found.