### PR TITLE
Add Stringify Filter for Jinja2 Rendering

### DIFF
--- a/contribs/documentation-template.yaml
+++ b/contribs/documentation-template.yaml
@@ -1,7 +1,7 @@
 structure:
   - README.md:
       content: |
-        # Project Name
+        # {{% project_name %}}
 
         Brief description of the project.
 
@@ -18,9 +18,11 @@ structure:
         Guidelines for contributing to the project.
   - CONTRIBUTING.md:
       content: |
-        # Contributing to Project Name
+        # Contributing to {{% project_name %}}
+
         ## How to Contribute
         Guidelines for how to contribute to the project.
+
         ## Code of Conduct
         Code of conduct for contributors.
   - CODE_OF_CONDUCT.md:
@@ -28,11 +30,4 @@ structure:
         # Code of Conduct
         Our standards for how to behave within our community.
   - LICENSE.md:
-      content: |
-        MIT License
-        Permission is hereby granted, free of charge, to any person obtaining a copy
-        of this software and associated documentation files (the "Software"), to deal
-        in the Software without restriction, including without limitation the rights
-        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-        copies of the Software, and to permit persons to whom the Software is
-        furnished to do so, subject to the following conditions:
+      file: https://raw.githubusercontent.com/git/git-scm.com/main/MIT-LICENSE.txt

--- a/contribs/kubernetes-manifests.yaml
+++ b/contribs/kubernetes-manifests.yaml
@@ -4,22 +4,22 @@ structure:
         apiVersion: apps/v1
         kind: Deployment
         metadata:
-          name: example-deployment
+          name: {{% deployment_name | stringify %}}
           labels:
-            app: example-app
+            app: {{% app_name | stringify %}}
         spec:
           replicas: 2
           selector:
             matchLabels:
-              app: example-app
+              app: {{% app_name | stringify %}}
           template:
             metadata:
               labels:
-                app: example-app
+                app: {{% app_name | stringify %}}
             spec:
               containers:
-              - name: example-container
-                image: nginx:latest
+              - name: {{% app_name | stringify %}}
+                image: {{% image_name %}}:{{% image_tag %}}
                 ports:
                 - containerPort: 80
   - service.yaml:
@@ -30,7 +30,7 @@ structure:
           name: example-service
         spec:
           selector:
-            app: example-app
+            app: {{% app_name | stringify %}}
           ports:
             - protocol: TCP
               port: 80
@@ -82,3 +82,21 @@ structure:
         kubectl apply -f configmap.yaml
         kubectl apply -f secrets.yaml
         ```
+
+variables:
+  app_name:
+    description: "The name of the application."
+    type: string
+    default: "example-app"
+  deployment_name:
+    description: "The name of the deployment"
+    type: string
+    default: "example-app-deployment"
+  image_name:
+    description: "The name of the Docker image."
+    type: string
+  image_tag:
+    description: "The tag of the Docker image."
+    type: string
+    default: "latest"
+

--- a/contribs/kubernetes-manifests.yaml
+++ b/contribs/kubernetes-manifests.yaml
@@ -99,4 +99,3 @@ variables:
     description: "The tag of the Docker image."
     type: string
     default: "latest"
-

--- a/contribs/terraform-app.yaml
+++ b/contribs/terraform-app.yaml
@@ -1,8 +1,8 @@
 structure:
   - main.tf:
       content: |
-        # This is the main Terraform configuration file.
-        touch_file: 2024-07-17
+        # This is the main Terraform app main file.
+        touch_file: {{% now().strftime('%Y-%m-%d') %}}
   - variables.tf:
       content: "# This is the Terraform variables file."
   - outputs.tf:

--- a/contribs/terraform-module.yaml
+++ b/contribs/terraform-module.yaml
@@ -19,12 +19,12 @@ structure:
         }
   - README.md:
       content: |
-        # Module Name
+        # {{% module_name %}}
         This module provisions an EC2 instance on AWS.
         ## Usage
         ```hcl
         module "example" {
-          source = "./module-name"
+          source = "./path/to/module/{{% module_name | stringify %}}"
           instance_type = "t2.micro"
         }
         ```

--- a/struct_module/filters.py
+++ b/struct_module/filters.py
@@ -1,4 +1,5 @@
 import os
+import re
 from github import Github
 
 def get_latest_release(repo_name):
@@ -23,3 +24,12 @@ def get_latest_release(repo_name):
         return default_branch
       except Exception as e:
         return "LATEST_RELEASE_ERROR"
+
+def stringify(value):
+    # Convert to lowercase
+    value = value.lower()
+    # Replace spaces with hyphens
+    value = re.sub(r'\s+', '-', value)
+    # Remove any non-alphanumeric characters (except hyphens)
+    value = re.sub(r'[^a-z0-9-]', '', value)
+    return value

--- a/struct_module/template_renderer.py
+++ b/struct_module/template_renderer.py
@@ -1,7 +1,7 @@
 # FILE: template_renderer.py
 import logging
 from jinja2 import Environment, meta
-from struct_module.filters import get_latest_release
+from struct_module.filters import get_latest_release, stringify
 
 class TemplateRenderer:
     def __init__(self, config_variables):
@@ -15,7 +15,12 @@ class TemplateRenderer:
         comment_start_string='{#@',
         comment_end_string='@#}'
       )
-      self.env.filters['latest_release'] = get_latest_release
+
+      custom_filters = {
+        'latest_release': get_latest_release,
+        'stringify': stringify,
+      }
+      self.env.filters.update(custom_filters)
       self.logger = logging.getLogger(__name__)
 
     # Get the config variables from the list and create a dictionary that has


### PR DESCRIPTION
This pull request introduces a new `stringify` filter to the Jinja2 templating engine, enhancing the flexibility and cleanliness of variable rendering within templates.

#### Changes:
- **Added `stringify` filter**:
  - Implemented a function that converts strings to lowercase, replaces spaces with hyphens, and removes non-alphanumeric characters.
  - This filter was added to `filters.py` and integrated into the Jinja2 environment in `template_renderer.py`.

#### Justification:
The `stringify` filter ensures that dynamically generated variable names are formatted in a consistent, URL-safe, and readable way, which is especially useful when rendering template values for deployment configurations.

#### Impact:
- Allows for better variable handling and formatting in Jinja2 templates, improving the clarity and reliability of dynamically generated content.