### PR TITLE
Refactor Commands to Handle Default Structure Paths

### DIFF
--- a/struct_module/commands/generate.py
+++ b/struct_module/commands/generate.py
@@ -9,7 +9,7 @@ class GenerateCommand(Command):
     super().__init__(parser)
     parser.add_argument('structure_definition', type=str, help='Path to the YAML configuration file')
     parser.add_argument('base_path', type=str, help='Base path where the structure will be created')
-    parser.add_argument('-s', '--structures-path', type=str, help='Path to structure definitions', default='contribs')
+    parser.add_argument('-s', '--structures-path', type=str, help='Path to structure definitions')
     parser.add_argument('-d', '--dry-run', action='store_true', help='Perform a dry run without creating any files or directories')
     parser.add_argument('-v', '--vars', type=str, help='Template variables in the format KEY1=value1,KEY2=value2')
     parser.add_argument('-b', '--backup', type=str, help='Path to the backup folder')
@@ -35,7 +35,11 @@ class GenerateCommand(Command):
       with open(args.structure_definition[7:], 'r') as f:
         config = yaml.safe_load(f)
     else:
-      file_path = os.path.join(args.structures_path, f"{args.structure_definition}.yaml")
+      if args.structures_path is None:
+        this_file = os.path.dirname(os.path.realpath(__file__))
+        file_path = os.path.join(this_file, "..", "..", "contribs", f"{args.structure_definition}.yaml")
+      else:
+        file_path = os.path.join(args.structures_path, f"{args.structure_definition}.yaml")
       # show error if file is not found
       if not os.path.exists(file_path):
         self.logger.error(f"File not found: {file_path}")

--- a/struct_module/commands/generate.py
+++ b/struct_module/commands/generate.py
@@ -4,6 +4,7 @@ import yaml
 import argparse
 from struct_module.file_item import FileItem
 from struct_module.completers import file_strategy_completer
+from struct_module.utils import project_path
 
 # Generate command class
 class GenerateCommand(Command):
@@ -41,7 +42,7 @@ class GenerateCommand(Command):
     else:
       if args.structures_path is None:
         this_file = os.path.dirname(os.path.realpath(__file__))
-        file_path = os.path.join(this_file, "..", "..", "contribs", f"{args.structure_definition}.yaml")
+        file_path = os.path.join(project_path, "contribs", f"{args.structure_definition}.yaml")
       else:
         file_path = os.path.join(args.structures_path, f"{args.structure_definition}.yaml")
       # show error if file is not found

--- a/struct_module/commands/list.py
+++ b/struct_module/commands/list.py
@@ -2,6 +2,7 @@ from struct_module.commands import Command
 import os
 import yaml
 from struct_module.file_item import FileItem
+from struct_module.utils import project_path
 
 # List command class
 class ListCommand(Command):
@@ -18,7 +19,7 @@ class ListCommand(Command):
 
     if args.structures_path is None:
       this_file = os.path.dirname(os.path.realpath(__file__))
-      final_path = os.path.join(this_file, "..", "..", "contribs")
+      final_path = os.path.join(project_path, "contribs")
     else:
       final_path = os.path.join(args.structures_path)
 

--- a/struct_module/commands/list.py
+++ b/struct_module/commands/list.py
@@ -1,0 +1,21 @@
+from struct_module.commands import Command
+import os
+import yaml
+from struct_module.file_item import FileItem
+
+# List command class
+class ListCommand(Command):
+  def __init__(self, parser):
+    super().__init__(parser)
+    parser.set_defaults(func=self.execute)
+
+  def execute(self, args):
+    self.logger.info(f"Listing available structures")
+    self._list_structures()
+
+  def _list_structures(self):
+    print("Listing available structures")
+    sorted_list = [structure for structure in os.listdir('contribs') if structure.endswith('.yaml')]
+    sorted_list.sort()
+    for structure in sorted_list:
+      print(f" - {structure[:-5]}")

--- a/struct_module/commands/list.py
+++ b/struct_module/commands/list.py
@@ -7,15 +7,23 @@ from struct_module.file_item import FileItem
 class ListCommand(Command):
   def __init__(self, parser):
     super().__init__(parser)
+    parser.add_argument('-s', '--structures-path', type=str, help='Path to structure definitions')
     parser.set_defaults(func=self.execute)
 
   def execute(self, args):
     self.logger.info(f"Listing available structures")
-    self._list_structures()
+    self._list_structures(args)
 
-  def _list_structures(self):
+  def _list_structures(self, args):
+
+    if args.structures_path is None:
+      this_file = os.path.dirname(os.path.realpath(__file__))
+      final_path = os.path.join(this_file, "..", "..", "contribs")
+    else:
+      final_path = os.path.join(args.structures_path)
+
     print("Listing available structures")
-    sorted_list = [structure for structure in os.listdir('contribs') if structure.endswith('.yaml')]
+    sorted_list = [structure for structure in os.listdir(final_path) if structure.endswith('.yaml')]
     sorted_list.sort()
     for structure in sorted_list:
       print(f" - {structure[:-5]}")

--- a/struct_module/main.py
+++ b/struct_module/main.py
@@ -5,6 +5,7 @@ from struct_module.utils import read_config_file, merge_configs
 from struct_module.commands.generate import GenerateCommand
 from struct_module.commands.info import InfoCommand
 from struct_module.commands.validate import ValidateCommand
+from struct_module.commands.list import ListCommand
 
 
 
@@ -23,6 +24,7 @@ def main():
     InfoCommand(subparsers.add_parser('info', help='Show information about the package'))
     ValidateCommand(subparsers.add_parser('validate', help='Validate the YAML configuration file'))
     GenerateCommand(subparsers.add_parser('generate', help='Generate the project structure'))
+    ListCommand(subparsers.add_parser('list', help='List available structures'))
 
     args = parser.parse_args()
 

--- a/struct_module/utils.py
+++ b/struct_module/utils.py
@@ -1,5 +1,5 @@
 import yaml
-
+import os
 
 def read_config_file(file_path):
     with open(file_path, 'r') as f:
@@ -12,3 +12,5 @@ def merge_configs(file_config, args):
         if key in args_dict and args_dict[key] is None:
             args_dict[key] = value
     return args_dict
+
+project_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")


### PR DESCRIPTION
#### Overview:
This pull request refactors the command modules in `generate.py` and `list.py` to handle cases where the `structures_path` argument is not provided, falling back to a default path.

#### Changes:
- **`generate.py`**: 
  - Removed the default value for `--structures-path` argument.
  - Added logic to fallback to a default path (`contribs`) if no path is provided.
- **`list.py`**: 
  - Modified the list command to handle optional `structures-path`.
  - Implemented fallback logic to default `contribs` directory when no path is specified.

#### Justification:
This refactor allows for greater flexibility when using the commands by enabling the user to provide custom paths for structure definitions or rely on the default path if none is supplied.

#### Impact:
- Improves the robustness of the commands by ensuring default paths are used if the user does not explicitly specify a path.
- Simplifies the interface for users running commands without additional configuration.