### PR TITLE
Add `default_branch` Filter for use on struct templates

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -238,6 +238,14 @@ structure:
 
 Este filtro obtiene el nombre de la rama predeterminada de un repositorio de GitHub. Toma el nombre del repositorio como argumento.
 
+```yaml
+structure:
+  - README.md:
+      content: |
+        # MyProject
+        Default branch: {{@ "httpdss/struct" | default_branch @}}
+```
+
 ### Cláusula `with`
 
 La cláusula `with` te permite pasar variables adicionales a estructuras anidadas. Estas variables se fusionarán con las variables globales y se pueden usar dentro de la estructura anidada.

--- a/README.es.md
+++ b/README.es.md
@@ -234,6 +234,10 @@ structure:
         slugify project_name: {{@ project_name | slugify @}}
 ```
 
+##### `default_branch`
+
+Este filtro obtiene el nombre de la rama predeterminada de un repositorio de GitHub. Toma el nombre del repositorio como argumento.
+
 ### Cláusula `with`
 
 La cláusula `with` te permite pasar variables adicionales a estructuras anidadas. Estas variables se fusionarán con las variables globales y se pueden usar dentro de la estructura anidada.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ structure:
 
 This filter fetches the default branch name of a GitHub repository. It takes the repository name as an argument.
 
+```yaml
+structure:
+  - README.md:
+      content: |
+        # MyProject
+        Default branch: {{@ "httpdss/struct" | default_branch @}}
+```
+
 ### `with` Clause
 
 The `with` clause allows you to pass additional variables to nested structures. These variables will be merged with the global variables and can be used within the nested structure.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ structure:
         slugify project_name: {{@ project_name | slugify @}}
 ```
 
+##### `default_branch`
+
+This filter fetches the default branch name of a GitHub repository. It takes the repository name as an argument.
+
 ### `with` Clause
 
 The `with` clause allows you to pass additional variables to nested structures. These variables will be merged with the global variables and can be used within the nested structure.

--- a/struct_module/filters.py
+++ b/struct_module/filters.py
@@ -25,6 +25,20 @@ def get_latest_release(repo_name):
       except Exception as e:
         return "LATEST_RELEASE_ERROR"
 
+def get_default_branch(repo_name):
+    token = os.getenv('GITHUB_TOKEN')
+
+    if token:
+        g = Github(token)
+    else:
+        g = Github()
+
+    try:
+        repo = g.get_repo(repo_name)
+        return repo.default_branch
+    except Exception:
+        return "DEFAULT_BRANCH_ERROR"
+
 def slugify(value):
     # Convert to lowercase
     value = value.lower()

--- a/struct_module/template_renderer.py
+++ b/struct_module/template_renderer.py
@@ -1,7 +1,7 @@
 # FILE: template_renderer.py
 import logging
 from jinja2 import Environment, meta
-from struct_module.filters import get_latest_release, slugify
+from struct_module.filters import get_latest_release, slugify, get_default_branch
 from struct_module.input_store import InputStore
 
 class TemplateRenderer:
@@ -20,6 +20,7 @@ class TemplateRenderer:
       custom_filters = {
         'latest_release': get_latest_release,
         'slugify': slugify,
+        'default_branch': get_default_branch
       }
       self.env.filters.update(custom_filters)
       self.logger = logging.getLogger(__name__)


### PR DESCRIPTION

#### Overview
This PR introduces a new `default_branch` filter, enabling users to dynamically fetch the default branch name of a specified GitHub repository. This feature enhances the automation and accuracy of project templates.

#### Changes
- **Documentation**:
  - Updated `README.md` and `README.es.md` with detailed examples of how to use the `default_branch` filter.
- **Filter Implementation**:
  - Added `get_default_branch` function in `filters.py` to fetch the default branch using the GitHub API.
  - Integrated the `default_branch` filter into the Jinja2 environment in `template_renderer.py`.
- **Code Adjustments**:
  - Updated `template_renderer.py` to support the new filter.
  
#### Justification
The `default_branch` filter allows users to seamlessly incorporate the default branch name of a GitHub repository into their templates, ensuring consistency and reducing manual input. This feature is particularly useful in CI/CD pipelines and dynamic project configurations.

#### Impact
- Improved flexibility and automation in project templates.
- Requires a valid GitHub token for private repository access, ensuring secure API interactions.
- Maintains backward compatibility with existing templates.