### PR TITLE
Add GitHub Actions workflow for stale issue and PR management

### DIFF
--- a/struct_module/contribs/github/workflows/stale.yaml
+++ b/struct_module/contribs/github/workflows/stale.yaml
@@ -1,5 +1,5 @@
 structure:
-  - .github/workflows/stale.yaml
+  - .github/workflows/stale.yaml:
       content: |
         name: 'stale'
         on:

--- a/struct_module/contribs/github/workflows/stale.yaml
+++ b/struct_module/contribs/github/workflows/stale.yaml
@@ -1,0 +1,16 @@
+structure:
+  - .github/workflows/stale.yaml
+      content: |
+        name: 'stale'
+        on:
+          schedule:
+            - cron: '30 1 * * *'
+
+        jobs:
+          stale:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/stale@{{@ "actions/stale" | latest_release  @}}
+                with:
+                  stale-issue-message: 'Message to comment on stale issues. If none provided, will not mark issues stale'
+                  stale-pr-message: 'Message to comment on stale PRs. If none provided, will not mark PRs stale'


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automatically manage stale issues and pull requests, including scheduled comments for inactivity.