### PR TITLE
Add support for kubectl configuration file .kuberc

### DIFF
--- a/struct_module/contribs/configs/kubectl.yaml
+++ b/struct_module/contribs/configs/kubectl.yaml
@@ -1,0 +1,23 @@
+files:
+  - .kuberc:
+      content: |
+        apiVersion: kubectl.config.k8s.io/v1alpha1
+        kind: Preference
+        # alias "kubectl crns" for "kubectl create namespace {{@ namespace @}}"
+        aliases:
+          - name: crns
+            command: create namespace
+            appendArgs:
+              - {{@ namespace @}}
+        # Force the --interactive=true flag for kubectl delete
+        overrides:
+          - command: delete
+            flags:
+              - name: interactive
+                default: "true"
+
+variables:
+  - name: namespace
+    description: The name of the namespace to create.
+    type: string
+    default: default


### PR DESCRIPTION
Introduce a kubectl configuration file that includes settings for creating and deleting namespaces, along with command aliases for easier namespace management.