### PR TITLE
Add n8n configuration with Docker setup

### DIFF
--- a/struct_module/contribs/project/n8n.yaml
+++ b/struct_module/contribs/project/n8n.yaml
@@ -1,0 +1,96 @@
+files:
+  - .env:
+      content: |
+        # DOMAIN_NAME and SUBDOMAIN together determine where n8n will be reachable from
+        # The top level domain to serve from
+        DOMAIN_NAME={{@ n8n_domain_name @}}
+
+        # The subdomain to serve from
+        SUBDOMAIN={{@ n8n_subdomain @}}
+
+        # The above example serve n8n at: https://n8n.{{@ n8n_domain_name @}}}}
+
+        # Optional timezone to set which gets used by Cron and other scheduling nodes
+        # New York is the default value if not set
+        GENERIC_TIMEZONE={{@ n8n_generic_timezone @}}
+
+        # The email address to use for the TLS/SSL certificate creation
+        SSL_EMAIL=user@{{@ n8n_ssl_email @}}}}
+  - local-files/.gitkeep:
+      content: |
+        # Keep this file to ensure the local-files directory is included in version control
+  - docker-compose.yaml:
+      content: |
+        services:
+          traefik:
+            image: "traefik"
+            restart: always
+            command:
+              - "--api.insecure=true"
+              - "--providers.docker=true"
+              - "--providers.docker.exposedbydefault=false"
+              - "--entrypoints.web.address=:80"
+              - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+              - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+              - "--entrypoints.websecure.address=:443"
+              - "--certificatesresolvers.mytlschallenge.acme.tlschallenge=true"
+              - "--certificatesresolvers.mytlschallenge.acme.email=${SSL_EMAIL}"
+              - "--certificatesresolvers.mytlschallenge.acme.storage=/letsencrypt/acme.json"
+            ports:
+              - "80:80"
+              - "443:443"
+            volumes:
+              - traefik_data:/letsencrypt
+              - /var/run/docker.sock:/var/run/docker.sock:ro
+
+          n8n:
+            image: docker.n8n.io/n8nio/n8n
+            restart: always
+            ports:
+              - "127.0.0.1:5678:5678"
+            labels:
+              - traefik.enable=true
+              - traefik.http.routers.n8n.rule=Host(`${SUBDOMAIN}.${DOMAIN_NAME}`)
+              - traefik.http.routers.n8n.tls=true
+              - traefik.http.routers.n8n.entrypoints=web,websecure
+              - traefik.http.routers.n8n.tls.certresolver=mytlschallenge
+              - traefik.http.middlewares.n8n.headers.SSLRedirect=true
+              - traefik.http.middlewares.n8n.headers.STSSeconds=315360000
+              - traefik.http.middlewares.n8n.headers.browserXSSFilter=true
+              - traefik.http.middlewares.n8n.headers.contentTypeNosniff=true
+              - traefik.http.middlewares.n8n.headers.forceSTSHeader=true
+              - traefik.http.middlewares.n8n.headers.SSLHost=${DOMAIN_NAME}
+              - traefik.http.middlewares.n8n.headers.STSIncludeSubdomains=true
+              - traefik.http.middlewares.n8n.headers.STSPreload=true
+              - traefik.http.routers.n8n.middlewares=n8n@docker
+            environment:
+              - N8N_HOST=${SUBDOMAIN}.${DOMAIN_NAME}
+              - N8N_PORT=5678
+              - N8N_PROTOCOL=https
+              - NODE_ENV=production
+              - WEBHOOK_URL=https://${SUBDOMAIN}.${DOMAIN_NAME}/
+              - GENERIC_TIMEZONE=${GENERIC_TIMEZONE}
+            volumes:
+              - n8n_data:/home/node/.n8n
+              - ./local-files:/files
+
+        volumes:
+          n8n_data:
+          traefik_data:
+
+variables:
+  - n8n_domain_name:
+      description: "The top level domain to serve n8n from"
+      type: string
+      default: "localtest.me"
+  - n8n_subdomain:
+      description: "The subdomain to serve n8n from"
+      type: string
+      default: "n8n"
+  - n8n_generic_timezone:
+      description: "The timezone to set for n8n, used by Cron and scheduling nodes"
+      type: string
+      default: "America/New_York"
+  - n8n_ssl_email:
+      description: "The email address to use for TLS/SSL certificate creation"
+      type: string


### PR DESCRIPTION
Introduce an n8n configuration file that includes environment variables and a Docker setup for deployment. This setup facilitates the use of Traefik as a reverse proxy and ensures proper handling of SSL certificates. The configuration allows customization of domain, subdomain, timezone, and SSL email.