### PR TITLE
Add Documentation button to hero section

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -144,6 +144,10 @@
           <i class="fas fa-download"></i>
           Get Started
         </a>
+        <a href="/struct/docs/" target="_blank" class="btn btn-secondary btn-lg">
+          <i class="fas fa-book"></i>
+          Documentation
+        </a>
         <a href="https://github.com/httpdss/struct" target="_blank" class="btn btn-secondary btn-lg">
           <i class="fab fa-github"></i>
           View on GitHub


### PR DESCRIPTION
## Summary

Adds a Documentation button between the "Get Started" and "View on GitHub" buttons in the hero section of the landing page.

## Changes

- Added new Documentation button linking to `/struct/docs/`
- Uses `fas fa-book` icon for consistent styling with other buttons
- Positioned between Get Started and View on GitHub buttons
- Opens in new tab for better user experience
- Maintains consistent styling with existing secondary buttons

## Screenshots

The Documentation button now appears in the center position between the two existing buttons, providing easy access to the project documentation.

## Testing

- ✅ Button displays correctly in hero section
- ✅ Link points to `/struct/docs/` as requested
- ✅ Opens in new tab (`target="_blank"`)
- ✅ Uses appropriate book icon (`fas fa-book`)
- ✅ Styling matches other secondary buttons