### PR TITLE
Fix: protocol handling in ContentFetcher for githubhttps:// prefix

### DIFF
--- a/struct_module/content_fetcher.py
+++ b/struct_module/content_fetcher.py
@@ -53,7 +53,10 @@ class ContentFetcher:
 
     for prefix, method in protocol_map.items():
       if content_location.startswith(prefix):
-        if content_location.startswith("http"):
+        # Only treat the raw HTTPS prefix as a direct URL fetch. All other
+        # custom prefixes (e.g., githubhttps://, githubssh://) should have
+        # their prefix stripped and be dispatched to the appropriate handler.
+        if prefix == "https://":
           return method(content_location)
         else:
           return method(content_location[len(prefix):])


### PR DESCRIPTION
Fixes #91

- Make protocol dispatch explicit in ContentFetcher: only exact `https://` is treated as a raw URL.
- Ensures `githubhttps://` and `githubssh://` prefixes are stripped and routed to the correct handlers.
- All tests pass locally (88 tests).