### PR TITLE
feat(generate): default structure_definition and base_path when omitted

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -59,13 +59,22 @@ Generate the project structure.
 **Usage:**
 
 ```sh
-struct generate [-h] [-l LOG] [-c CONFIG_FILE] [-i LOG_FILE] [-s STRUCTURES_PATH] [-n INPUT_STORE] [-d] [--diff] [-v VARS] [-b BACKUP] [-f {overwrite,skip,append,rename,backup}] [-p GLOBAL_SYSTEM_PROMPT] [--non-interactive] [--mappings-file MAPPINGS_FILE] [-o {console,file}] structure_definition base_path
+struct generate [-h] [-l LOG] [-c CONFIG_FILE] [-i LOG_FILE] [-s STRUCTURES_PATH] [-n INPUT_STORE] [-d] [--diff] [-v VARS] [-b BACKUP] [-f {overwrite,skip,append,rename,backup}] [-p GLOBAL_SYSTEM_PROMPT] [--non-interactive] [--mappings-file MAPPINGS_FILE] [-o {console,file}] [structure_definition] [base_path]
+```
+
+Defaults when omitted:
+- structure_definition -> .struct.yaml
+- base_path -> .
+
+Example:
+```sh
+struct generate
 ```
 
 **Arguments:**
 
-- `structure_definition`: Path to the YAML configuration file.
-- `base_path`: Base path where the structure will be created.
+- `structure_definition` (optional): Path to the YAML configuration file (default: `.struct.yaml`).
+- `base_path` (optional): Base path where the structure will be created (default: `.`).
 - `-s STRUCTURES_PATH, --structures-path STRUCTURES_PATH`: Path to structure definitions.
 - `-n INPUT_STORE, --input-store INPUT_STORE`: Path to the input store.
 - `-d, --dry-run`: Perform a dry run without creating any files or directories.
@@ -138,6 +147,14 @@ struct init [path]
 - Non-destructive: if .struct.yaml already exists, it is not overwritten and a message is printed.
 
 ## Examples
+
+### Using Defaults
+
+Generate with default structure (.struct.yaml) into current directory:
+
+```sh
+struct generate
+```
 
 ### Basic Structure Generation
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,7 +43,7 @@ vim structure.yaml # copy the content from the example folder
 struct generate structure.yaml .
 ```
 
-> **Note**: The `file://` protocol is automatically added for `.yaml` files, so `structure.yaml` and `file://structure.yaml` work identically.
+> Note: The `file://` protocol is automatically added for `.yaml` files, so `structure.yaml` and `file://structure.yaml` work identically. Additionally, if your file is named `.struct.yaml` in the current directory and you want to generate into the current directory, you can just run `struct generate`.
 
 ## Discovering Available Structures
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,6 +33,14 @@ struct generate <Tab>
 # Shows all available structures
 ```
 
+### Using Defaults
+
+If you have a .struct.yaml in the current directory and want to generate into the current directory, you can simply run:
+
+```sh
+struct generate
+```
+
 ### Simple Example
 
 ```sh
@@ -47,6 +55,12 @@ For local YAML configuration files, the `file://` protocol is automatically adde
 # Both of these work identically
 struct generate my-config.yaml ./output
 struct generate file://my-config.yaml ./output
+```
+
+Tip: If your config file is named `.struct.yaml` in the current directory and you want to generate into the current directory, you can simply run:
+
+```sh
+struct generate
 ```
 
 ### Diff Preview Example

--- a/struct_module/commands/generate.py
+++ b/struct_module/commands/generate.py
@@ -13,9 +13,9 @@ class GenerateCommand(Command):
   def __init__(self, parser):
     super().__init__(parser)
     parser.description = "Generate the project structure from a YAML configuration file"
-    structure_arg = parser.add_argument('structure_definition', type=str, help='Path to the YAML configuration file')
+    structure_arg = parser.add_argument('structure_definition', nargs='?', default='.struct.yaml', type=str, help='Path to the YAML configuration file (default: .struct.yaml)')
     structure_arg.completer = structures_completer
-    parser.add_argument('base_path', type=str, help='Base path where the structure will be created')
+    parser.add_argument('base_path', nargs='?', default='.', type=str, help='Base path where the structure will be created (default: current directory)')
     parser.add_argument('-s', '--structures-path', type=str, help='Path to structure definitions')
     parser.add_argument('-n', '--input-store', type=str, help='Path to the input store', default='/tmp/struct/input.json')
     parser.add_argument('-d', '--dry-run', action='store_true', help='Perform a dry run without creating any files or directories')


### PR DESCRIPTION
Summary
This PR improves the UX of the generate command by making both positional arguments optional with sensible defaults. Users can now run struct generate with no additional arguments when a .struct.yaml is present in the current directory.

Motivation
- Streamline the most common workflow: running generation from the current directory using a local .struct.yaml.
- Reduce friction and boilerplate for quick iterations and demos.

Changes
- CLI: Make positional args optional in GenerateCommand
  - structure_definition defaults to .struct.yaml
  - base_path defaults to .
  - Explicitly provided arguments continue to override these defaults.
- Docs: Updated to reflect new defaults
  - docs/cli-reference.md
  - docs/usage.md
  - docs/quickstart.md

Usage
```sh
# With defaults (if .struct.yaml exists in the current directory)
struct generate

# From a specific YAML file into a target directory (unchanged)
struct generate file://my-config.yaml ./output

# Using a built-in structure definition into a directory (unchanged)
struct generate python-basic ./my-project
```

Backward compatibility
- Existing commands remain valid; this is an additive improvement.
- Explicit arguments still take precedence over defaults.

Testing
- Full test suite executed locally: 112 tests passed.
- No behavior changes to existing flows other than allowing omitted positional args with sensible defaults.

Docs
- CLI reference updated to show optional positional args and defaults.
- Usage and Quickstart updated with examples using struct generate without arguments.

Closes #113.