### PR TITLE
feat: display variable descriptions in interactive mode prompts

### DIFF
--- a/docs/template-variables.md
+++ b/docs/template-variables.md
@@ -66,7 +66,7 @@ STRUCT provides these built-in variables:
 
 ## Interactive Variables
 
-Define variables that prompt users for input:
+Define variables that prompt users for input. When running in interactive mode, STRUCT will display the variable's description to help users understand what value is expected:
 
 ```yaml
 variables:
@@ -83,6 +83,17 @@ variables:
       type: integer
       default: 8080
 ```
+
+When prompted interactively, variables with descriptions will display like this:
+
+```
+❓ Enter value for project_name [MyProject]:
+   Description: The name of your project
+❓ Enter value for author_name []:
+   Description: Your name
+```
+
+**Note**: The `description` field is displayed in interactive mode only. You can also use the legacy `help` field which works the same way.
 
 ### Variable Types
 

--- a/struct_module/template_renderer.py
+++ b/struct_module/template_renderer.py
@@ -127,10 +127,23 @@ class TemplateRenderer:
           else:
             # Interactive prompt with enum support (choose by value or index)
             enum = conf.get('enum')
+
+            # Get description if available (support both 'description' and 'help' fields)
+            description = conf.get('description') or conf.get('help')
+
             if enum:
               # Build options list string like "(1) dev, (2) prod)"
               options = ", ".join([f"({i+1}) {val}" for i, val in enumerate(enum)])
-              raw = input(f"❓ Enter value for {var} [{default}] {options}: ")
+              prompt = f"❓ Enter value for {var} [{default}] {options}: "
+
+              # Display description on a new line if available
+              if description:
+                print(prompt.rstrip())
+                print(f"   Description: {description}")
+                raw = input("   ") or default
+              else:
+                raw = input(prompt) or default
+
               raw = raw.strip()
               if raw == "":
                 user_input = default
@@ -142,7 +155,15 @@ class TemplateRenderer:
                 # For invalid enum input, raise immediately instead of re-prompting
                 raise ValueError(f"Variable '{var}' must be one of {enum}, got: {raw}")
             else:
-              user_input = input(f"❓ Enter value for {var} [{default}]: ") or default
+              prompt = f"❓ Enter value for {var} [{default}]: "
+
+              # Display description on a new line if available
+              if description:
+                print(prompt.rstrip())
+                print(f"   Description: {description}")
+                user_input = input("   ") or default
+              else:
+                user_input = input(prompt) or default
           # Coerce and validate according to schema
           coerced = self._coerce_and_validate(var, user_input, conf)
           self.input_store.set_value(var, coerced)

--- a/tests/test_template_renderer.py
+++ b/tests/test_template_renderer.py
@@ -105,3 +105,83 @@ def test_render_template_with_mappings():
         config_variables, input_store, non_interactive, mappings=mappings_dot)
     rendered_content_dot = renderer_dot.render_template(content_dot, {})
     assert rendered_content_dot == "Account: 123456789"
+
+
+def test_prompt_with_description_display():
+    """Test that variable descriptions are displayed in interactive prompts"""
+    config_variables = [
+        {"project_name": {
+            "type": "string",
+            "description": "The name of your project",
+            "default": "MyProject"
+        }},
+        {"environment": {
+            "type": "string",
+            "description": "Target deployment environment",
+            "enum": ["dev", "staging", "prod"],
+            "default": "dev"
+        }},
+        {"old_style_help": {
+            "type": "string",
+            "help": "This uses the old 'help' field",
+            "default": "test"
+        }},
+        {"no_description": {
+            "type": "string",
+            "default": "test"
+        }}
+    ]
+    input_store = "/tmp/input.json"
+    non_interactive = False
+    renderer = TemplateRenderer(config_variables, input_store, non_interactive)
+
+    # Test each variable type separately to ensure proper input handling
+
+    # Test 1: Regular variable with description
+    content1 = "{{@ project_name @}}"
+    vars1 = {}
+    with patch('builtins.input', return_value="TestProject") as mock_input, \
+         patch('builtins.print') as mock_print:
+        result_vars1 = renderer.prompt_for_missing_vars(content1, vars1)
+        assert result_vars1["project_name"] == "TestProject"
+
+        # Check that description was printed
+        print_calls = [call.args[0] for call in mock_print.call_args_list]
+        assert any("Description: The name of your project" in call for call in print_calls)
+
+    # Test 2: Enum variable with description
+    content2 = "{{@ environment @}}"
+    vars2 = {}
+    with patch('builtins.input', return_value="prod") as mock_input, \
+         patch('builtins.print') as mock_print:
+        result_vars2 = renderer.prompt_for_missing_vars(content2, vars2)
+        assert result_vars2["environment"] == "prod"
+
+        # Check that description was printed for enum
+        print_calls = [call.args[0] for call in mock_print.call_args_list]
+        assert any("Description: Target deployment environment" in call for call in print_calls)
+
+    # Test 3: Variable with 'help' field (backward compatibility)
+    content3 = "{{@ old_style_help @}}"
+    vars3 = {}
+    with patch('builtins.input', return_value="help_test") as mock_input, \
+         patch('builtins.print') as mock_print:
+        result_vars3 = renderer.prompt_for_missing_vars(content3, vars3)
+        assert result_vars3["old_style_help"] == "help_test"
+
+        # Check that help was printed as description
+        print_calls = [call.args[0] for call in mock_print.call_args_list]
+        assert any("Description: This uses the old 'help' field" in call for call in print_calls)
+
+    # Test 4: Variable without description (should not print description)
+    content4 = "{{@ no_description @}}"
+    vars4 = {}
+    with patch('builtins.input', return_value="no_desc_test") as mock_input, \
+         patch('builtins.print') as mock_print:
+        result_vars4 = renderer.prompt_for_missing_vars(content4, vars4)
+        assert result_vars4["no_description"] == "no_desc_test"
+
+        # Check that no description was printed
+        print_calls = [call.args[0] for call in mock_print.call_args_list]
+        # Should not contain any description text
+        assert not any("Description:" in call for call in print_calls)


### PR DESCRIPTION
## Description

This PR implements the feature requested in issue #116 to display variable descriptions in interactive mode prompts, enhancing the user experience when generating project structures.

## Changes Made

### Core Implementation
- **Modified `struct_module/template_renderer.py`**: Updated the `prompt_for_missing_vars` method to display variable descriptions during interactive prompts
- Added support for both `description` and `help` fields for backward compatibility
- Descriptions are displayed on a separate line with proper indentation for clarity
- Only displays descriptions when they exist in the variable configuration

### Testing
- **Added comprehensive test**: `test_prompt_with_description_display()` in `tests/test_template_renderer.py`
- Tests cover all scenarios:
  - Variables with `description` field
  - Variables with enum options and descriptions
  - Variables with legacy `help` field
  - Variables without descriptions (ensuring no description is shown)
- All existing tests continue to pass

### Documentation
- **Updated `docs/template-variables.md`**: Added explanation of the new description display feature
- Included examples of how prompts appear with descriptions
- Documented support for both `description` and `help` fields

## Example Output

### Before (without descriptions)
```
❓ Enter value for project_name [MyProject]: 
❓ Enter value for environment [dev] (1) dev, (2) staging, (3) prod: 
```

### After (with descriptions)
```
❓ Enter value for project_name [MyProject]: 
   Description: The name of your project
❓ Enter value for environment [dev] (1) dev, (2) staging, (3) prod: 
   Description: Target deployment environment
```

## Backward Compatibility

✅ **Fully backward compatible**
- Variables without descriptions work exactly as before
- Supports legacy `help` field in addition to `description`
- No breaking changes to existing functionality
- All existing tests pass

## Benefits

- **Improved UX**: Users can understand what each variable represents without checking the YAML file
- **Self-documenting**: Configurations become more user-friendly
- **Flexible**: Works with both regular variables and enum-based selections
- **Clean**: Only displays descriptions when available, maintaining clean prompts otherwise

## Testing

```bash
# Run all template renderer tests
pytest tests/test_template_renderer.py -v

# Run specific test for this feature
pytest tests/test_template_renderer.py::test_prompt_with_description_display -v
```

Closes #116