### PR TITLE
docs(contribs): add description field to all contribs YAML files

### DIFF
--- a/structkit/contribs/ansible-playbook.yaml
+++ b/structkit/contribs/ansible-playbook.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates an Ansible playbook scaffold with main.yml, vars.yml, tasks/main.yml,
+  handlers/main.yml, a templates directory, and a README.md.
+
 files:
   - main.yml:
       content: |

--- a/structkit/contribs/chef-cookbook.yaml
+++ b/structkit/contribs/chef-cookbook.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a Chef cookbook scaffold for configuring NGINX, including a default recipe,
+  node attributes, an nginx.conf.erb template, a default index.html, and a README.md.
+
 files:
   - recipes/default.rb:
       content: |

--- a/structkit/contribs/ci-cd-pipelines.yaml
+++ b/structkit/contribs/ci-cd-pipelines.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates CI/CD pipeline configuration files for multiple platforms: GitLab CI (.gitlab-ci.yml),
+  Jenkins (Jenkinsfile), and GitHub Actions (ci.yml and cd.yml) with build, test, and deploy stages.
+
 files:
   - .gitlab-ci.yml:
       content: |

--- a/structkit/contribs/cloudformation-files.yaml
+++ b/structkit/contribs/cloudformation-files.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates AWS CloudFormation files: a template.yaml defining an S3 bucket resource,
+  a parameters.json file, and a deploy.sh script for deploying the stack via the AWS CLI.
+
 files:
   - template.yaml:
       content: |

--- a/structkit/contribs/configs/chglog.yaml
+++ b/structkit/contribs/configs/chglog.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates git-chglog configuration files (.chglog/config.yaml and CHANGELOG.tpl.md)
+  for automated changelog generation with GitHub-style commit parsing and Markdown output.
+
 files:
   - .chglog/config.yaml:
       content: |

--- a/structkit/contribs/configs/codeowners.yaml
+++ b/structkit/contribs/configs/codeowners.yaml
@@ -1,3 +1,6 @@
+description: >
+  Creates a CODEOWNERS file assigning all repository files to a configurable GitHub username.
+
 files:
   - CODEOWNERS: |
       * @github_username

--- a/structkit/contribs/configs/devcontainer.yaml
+++ b/structkit/contribs/configs/devcontainer.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a VS Code dev container configuration using Python 3.12 (bullseye) with
+  yamlfmt and pre-commit features pre-installed.
+
 files:
   - .devcontainer/devcontainer.json:
       content: |

--- a/structkit/contribs/configs/editor-config.yaml
+++ b/structkit/contribs/configs/editor-config.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates an .editorconfig file enforcing consistent coding style across editors:
+  UTF-8, LF line endings, 2-space indentation, and trailing whitespace trimming.
+
 files:
   - .editorconfig:
       content: |

--- a/structkit/contribs/configs/eslint.yaml
+++ b/structkit/contribs/configs/eslint.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates ESLint configuration files (.eslintrc.json and .eslintignore) for a
+  React/ES2021 project with eslint:recommended and react/recommended rules enabled.
+
 files:
   - .eslintrc.json:
       content: |

--- a/structkit/contribs/configs/jshint.yaml
+++ b/structkit/contribs/configs/jshint.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates JSHint configuration files (.jshintrc and .jshintignore) for Node.js/ES6
+  JavaScript linting, excluding node_modules and dist directories.
+
 files:
   - .jshintrc:
       content: |

--- a/structkit/contribs/configs/kubectl.yaml
+++ b/structkit/contribs/configs/kubectl.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a .kuberc kubectl preferences file with a custom alias for creating namespaces
+  and a forced --interactive=true flag for kubectl delete commands.
+
 files:
   - .kuberc:
       content: |

--- a/structkit/contribs/configs/prettier.yaml
+++ b/structkit/contribs/configs/prettier.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates Prettier code-formatting configuration files (.prettierrc and .prettierignore)
+  with standard style settings: single quotes, ES5 trailing commas, 80-char print width.
+
 files:
   - .prettierrc:
       content: |

--- a/structkit/contribs/docker-files.yaml
+++ b/structkit/contribs/docker-files.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates Docker configuration files: a Dockerfile (nginx-based), .dockerignore,
+  a docker-compose.yml with web and db (MySQL) services, and a .env file.
+
 files:
   - Dockerfile:
       content: |

--- a/structkit/contribs/documentation-template.yaml
+++ b/structkit/contribs/documentation-template.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates standard open-source project documentation files: README.md, CONTRIBUTING.md,
+  CODE_OF_CONDUCT.md, and LICENSE.md, all templated with a project_name variable.
+
 files:
   - README.md:
       content: |

--- a/structkit/contribs/git-hooks.yaml
+++ b/structkit/contribs/git-hooks.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates executable Git hook shell scripts under .git/hooks/: pre-commit,
+  pre-push, and commit-msg, each with a placeholder for custom hook logic.
+
 files:
   - .git/hooks/pre-commit:
       permissions: 755

--- a/structkit/contribs/github/chatmodes/plan.yaml
+++ b/structkit/contribs/github/chatmodes/plan.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a GitHub Copilot chat mode file (plan.chatmode.md) that configures an AI
+  planning assistant for generating implementation plans without making any code edits.
+
 files:
   - ./github/chatmodes/plan.chatmode.md:
       content: |

--- a/structkit/contribs/github/instructions/generic.yaml
+++ b/structkit/contribs/github/instructions/generic.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a generic GitHub Copilot instructions file (.github/instructions/generic.instruction.md)
+  as a blank starter template for defining AI coding guidelines and context.
+
 files:
   - .github/instructions/generic.instruction.md:
       skip_if_exists: true

--- a/structkit/contribs/github/prompts/generic.yaml
+++ b/structkit/contribs/github/prompts/generic.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a generic GitHub Copilot prompt file (.github/prompts/generic.prompt.md)
+  as a blank starter template for defining reusable AI prompts.
+
 files:
   - .github/prompts/generic.prompt.md:
       content: |

--- a/structkit/contribs/github/prompts/react-form.yaml
+++ b/structkit/contribs/github/prompts/react-form.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a GitHub Copilot prompt for generating React form components using
+  react-hook-form (uncontrolled), yup validation schemas, and TypeScript types.
+
 files:
   - .github/prompts/react-form.prompt.md:
       content: |

--- a/structkit/contribs/github/prompts/security-api.yaml
+++ b/structkit/contribs/github/prompts/security-api.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a GitHub Copilot prompt for reviewing REST API security, covering
+  authentication, input validation, rate limiting, and security event logging.
+
 files:
   - .github/prompts/security-api.prompt.md:
       content: |

--- a/structkit/contribs/github/prompts/struct.yaml
+++ b/structkit/contribs/github/prompts/struct.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a GitHub Copilot prompt that configures an AI assistant for generating
+  valid .struct.yaml files for the StructKit tool, with schema references and usage examples.
+
 files:
   - .github/prompts/struct.prompt.md:
       content: |

--- a/structkit/contribs/github/templates.yaml
+++ b/structkit/contribs/github/templates.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates GitHub PR templates (bug fix, feature request, general PR) under
+  .github/PULL_REQUEST_TEMPLATE/ and an issue template under .github/ISSUE_TEMPLATE/.
+
 files:
   - .github/PULL_REQUEST_TEMPLATE/bug_fix_template.md:
       content: |

--- a/structkit/contribs/github/workflows/codeql.yaml
+++ b/structkit/contribs/github/workflows/codeql.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a GitHub Actions CodeQL analysis workflow (z-codeql.yaml) for JavaScript
+  security scanning, triggered on push/PR to default branches and on a weekly schedule.
+
 files:
   - .github/workflows/z-codeql.yaml:
       content: | # yaml

--- a/structkit/contribs/github/workflows/execute-tf-workflow.yaml
+++ b/structkit/contribs/github/workflows/execute-tf-workflow.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a GitHub Actions workflow for running Terraform plan on PRs and apply on pushes
+  to main, scoped to a specific app path under .devops/apps/. Uses variables for app name,
+  working directory path, and GitHub token.
+
 files:
   - .github/workflows/execute-tf-{{@ app_name | slugify @}}.yaml:
       content: |

--- a/structkit/contribs/github/workflows/labeler.yaml
+++ b/structkit/contribs/github/workflows/labeler.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a GitHub Actions labeler workflow (labeler.yaml) and a labeler config
+  (.github/labeler.yml) that auto-assigns PR labels based on changed file paths
+  and branch name patterns (feature, bug, docs, release).
+
 files:
   - .github/labeler.yml:
       content: |

--- a/structkit/contribs/github/workflows/pre-commit.yaml
+++ b/structkit/contribs/github/workflows/pre-commit.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a GitHub Actions pre-commit workflow (z-pre-commit.yaml) and a
+  .pre-commit-config.yaml with check-yaml, end-of-file-fixer, and trailing-whitespace hooks.
+
 files:
   - .github/workflows/z-pre-commit.yaml:
       content: |

--- a/structkit/contribs/github/workflows/release-drafter.yaml
+++ b/structkit/contribs/github/workflows/release-drafter.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a release drafter workflow (z-release-drafter.yaml), a major tagging workflow
+  (z-major-tagging.yaml), and a release-drafter.yml config with feature/bugfix/patch
+  label categories and semantic versioning resolution.
+
 files:
   - .github/workflows/z-release-drafter.yaml:
       content: |

--- a/structkit/contribs/github/workflows/run-struct.yaml
+++ b/structkit/contribs/github/workflows/run-struct.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a GitHub Actions workflow (run-struct.yaml) that can be manually triggered
+  via workflow_dispatch to run struct file generation, plus a starter .struct.yaml file.
+
 files:
   - .github/workflows/run-struct.yaml:
       skip_if_exists: true

--- a/structkit/contribs/github/workflows/stale.yaml
+++ b/structkit/contribs/github/workflows/stale.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a GitHub Actions workflow (stale.yaml) that runs daily on a cron schedule
+  to mark inactive issues and pull requests as stale with configurable messages.
+
 files:
   - .github/workflows/stale.yaml:
       content: |

--- a/structkit/contribs/helm-chart.yaml
+++ b/structkit/contribs/helm-chart.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a complete Helm chart scaffold including Chart.yaml, values.yaml,
+  Deployment/Service/Ingress templates, a helpers partial, and .helmignore.
+
 files:
   - Chart.yaml:
       content: |

--- a/structkit/contribs/kubernetes-manifests.yaml
+++ b/structkit/contribs/kubernetes-manifests.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates Kubernetes manifest files for deploying a containerised application:
+  Deployment, Service, Ingress, ConfigMap, Secret, and README.md.
+  Uses variables for app name, deployment name, and Docker image details.
+
 files:
   - deployment.yaml:
       content: |

--- a/structkit/contribs/project/custom-structures.yaml
+++ b/structkit/contribs/project/custom-structures.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates the scaffolding for a custom StructKit structures repository: README.md,
+  custom-mappings.yaml, a structures/ directory, and common configs via sub-structures
+  (devcontainer, editor-config, prettier, run-struct, release-drafter, pre-commit).
+
 files:
   - README.md:
       content: |

--- a/structkit/contribs/project/generic.yaml
+++ b/structkit/contribs/project/generic.yaml
@@ -1,3 +1,9 @@
+description: >
+  Creates a comprehensive generic project scaffold with standard directory structure
+  (.config, .build, src, test, doc, tools, dep), common config files (.editorconfig,
+  .gitignore, Dockerfile, docker-compose.yml), GitHub community files, and Terraform
+  environment apps (prod, stage, qa, dev, init).
+
 files:
   - .config/REMOVE_ME.md:
       content: |

--- a/structkit/contribs/project/go.yaml
+++ b/structkit/contribs/project/go.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a Go project scaffold with standard directory layout (cmd, pkg, internal, api, test),
+  main.go entry point, .editorconfig, .gitignore, README.md, and Apache 2.0 LICENSE.
+
 files:
   - .editorconfig:
       content: |

--- a/structkit/contribs/project/java.yaml
+++ b/structkit/contribs/project/java.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a Java Maven project scaffold with pom.xml, standard Maven directory layout
+  (src/main/java, src/test/java), App.java and AppTest.java starters, .editorconfig,
+  .gitignore, README.md, and Apache 2.0 LICENSE.
+
 files:
   - .editorconfig:
       content: |

--- a/structkit/contribs/project/n8n.yaml
+++ b/structkit/contribs/project/n8n.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a self-hosted n8n workflow automation setup with docker-compose.yaml
+  (n8n container + Traefik reverse proxy with automatic HTTPS), .env configuration,
+  and a local-files/ directory. Uses variables for domain, subdomain, timezone, and SSL email.
+
 files:
   - .gitignore:
       content: |

--- a/structkit/contribs/project/nodejs.yaml
+++ b/structkit/contribs/project/nodejs.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a Node.js project scaffold with package.json, src/index.js and utils.js,
+  public/index.html, a test starter, .editorconfig, .gitignore, README.md, and Apache 2.0 LICENSE.
+
 files:
   - .editorconfig:
       content: |

--- a/structkit/contribs/project/python.yaml
+++ b/structkit/contribs/project/python.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a Python project scaffold with setup.py, setup.cfg, pyproject.toml,
+  Makefile (with venv management), requirements.txt, src and tests directories
+  with starter modules, .editorconfig, .gitignore, and Apache 2.0 LICENSE.
+
 files:
   - .editorconfig:
       content: |

--- a/structkit/contribs/project/ruby.yaml
+++ b/structkit/contribs/project/ruby.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a Ruby project scaffold with .rubocop.yml, RSpec test structure (spec/),
+  lib directory with versioned module and main class, bin/console and bin/setup scripts,
+  .editorconfig, .gitignore, README.md, and Apache 2.0 LICENSE.
+
 files:
   - .editorconfig:
       content: |

--- a/structkit/contribs/project/rust.yaml
+++ b/structkit/contribs/project/rust.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a Rust project scaffold with Cargo.toml, src/main.rs and lib.rs, module files,
+  integration tests, benchmarks, .cargo/config for cross-compilation, .editorconfig,
+  .gitignore, README.md, and Apache 2.0 LICENSE.
+
 files:
   - .editorconfig:
       content: |

--- a/structkit/contribs/prompts/run-struct-trigger.yaml
+++ b/structkit/contribs/prompts/run-struct-trigger.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates an AI agent prompt file that instructs the assistant to query GitHub for
+  repositories matching a given topic in a specified organization, then trigger the
+  run-struct workflow on each of them.
+
 files:
   - run-struct-trigger.md:
       content: |

--- a/structkit/contribs/terraform/apps/aws-accounts.yaml
+++ b/structkit/contribs/terraform/apps/aws-accounts.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates Terraform app directories for nonprod and prod AWS accounts under
+  .devops/apps/accounts/, each using the generic app structure with a remote backend,
+  plus execute-tf-workflow GitHub Actions workflows for each account.
+
 folders:
   - .devops/apps/accounts/nonprod:
       struct: terraform/apps/generic

--- a/structkit/contribs/terraform/apps/environments.yaml
+++ b/structkit/contribs/terraform/apps/environments.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates Terraform app directories for four environments (dev, qa, stage, prod) under
+  .devops/apps/environments/, using the generic app structure with a remote backend,
+  plus execute-tf-workflow GitHub Actions workflows for each environment.
+
 folders:
   - .devops/apps/environments/dev:
       struct: terraform/apps/generic

--- a/structkit/contribs/terraform/apps/generic.yaml
+++ b/structkit/contribs/terraform/apps/generic.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a generic Terraform app scaffold with main.tf, variables.tf, outputs.tf,
+  providers.tf (with a remote backend on app.terraform.io), and README.md.
+  Uses variables for the remote backend organization and workspace names.
+
 files:
   - main.tf:
       content: |

--- a/structkit/contribs/terraform/apps/github-organization.yaml
+++ b/structkit/contribs/terraform/apps/github-organization.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates Terraform files for managing a GitHub organization: providers.tf with the
+  GitHub provider and a remote backend, plus main.tf, variables.tf, outputs.tf, and README.md.
+
 files:
   - providers.yaml:
       content: |

--- a/structkit/contribs/terraform/apps/init.yaml
+++ b/structkit/contribs/terraform/apps/init.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a Terraform init app directory under .devops/apps/init/ using the generic
+  app structure with a remote backend, plus an execute-tf-workflow GitHub Actions workflow.
+
 folders:
   - .devops/apps/init:
       struct: terraform/apps/generic

--- a/structkit/contribs/terraform/modules/generic.yaml
+++ b/structkit/contribs/terraform/modules/generic.yaml
@@ -1,3 +1,8 @@
+description: >
+  Creates a generic Terraform module scaffold with main.tf (EC2 instance example),
+  variables.tf, outputs.tf, versions.tf (with AWS and Datadog providers auto-versioned),
+  and README.md. Uses a module_name variable for documentation templating.
+
 files:
   - main.tf:
       content: |

--- a/structkit/contribs/vagrant-files.yaml
+++ b/structkit/contribs/vagrant-files.yaml
@@ -1,3 +1,7 @@
+description: >
+  Creates a Vagrant development environment with a Vagrantfile (Ubuntu bionic64),
+  an executable bootstrap.sh provisioning script that installs nginx, and a README.md.
+
 files:
   - Vagrantfile:
       content: |


### PR DESCRIPTION
## Problem
The YAML files under `structkit/contribs/` had no `description` field, making it impossible to quickly understand what each structure generates without reading its full content.

## Solution
Added a top-level `description: >` field to every YAML file under `structkit/contribs/`, consistent with common StructKit conventions. Each description provides a concise, human-readable summary of what the structure creates or configures.

## Changes
Added `description` to all 46 YAML files across:
- Root-level structures (ansible-playbook, chef-cookbook, ci-cd-pipelines, cloudformation-files, docker-files, documentation-template, git-hooks, helm-chart, kubernetes-manifests, vagrant-files)
- `configs/` (chglog, codeowners, devcontainer, editor-config, eslint, jshint, kubectl, prettier)
- `github/chatmodes/` (plan)
- `github/instructions/` (generic)
- `github/prompts/` (generic, react-form, security-api, struct)
- `github/templates`
- `github/workflows/` (codeql, execute-tf-workflow, labeler, pre-commit, release-drafter, run-struct, stale)
- `project/` (custom-structures, generic, go, java, n8n, nodejs, python, ruby, rust)
- `prompts/` (run-struct-trigger)
- `terraform/apps/` (aws-accounts, environments, generic, github-organization, init)
- `terraform/modules/` (generic)

## Testing
- All pre-commit hooks (check-yaml, end-of-file-fixer, trailing-whitespace) passed
- No existing structure content was modified, only descriptions were prepended