### PR TITLE
[#166] Make --input-store errors user-friendly, including relative paths and corrupt JSON

### DIFF
--- a/structkit/commands/generate.py
+++ b/structkit/commands/generate.py
@@ -6,6 +6,7 @@ from structkit.file_item import FileItem, ContentFetchError
 from structkit.completers import file_strategy_completer, structures_completer
 from structkit.template_renderer import TemplateRenderer, TemplateVariableError
 from structkit.sources import SourceError, resolve_structures_path
+from structkit.input_store import InputStoreError
 
 import subprocess
 
@@ -207,7 +208,7 @@ class GenerateCommand(Command):
     # Actually generate structure
     try:
       self._create_structure(args, mappings)
-    except (GenerateConfigError, TemplateVariableError, ContentFetchError) as exc:
+    except (GenerateConfigError, TemplateVariableError, ContentFetchError, InputStoreError) as exc:
       self.logger.error(f"❗ {exc}")
       raise SystemExit(1) from None
 

--- a/structkit/input_store.py
+++ b/structkit/input_store.py
@@ -2,25 +2,48 @@ import json
 import os
 
 
+class InputStoreError(Exception):
+  """Raised when the input store cannot be read, written, or parsed."""
+
+
 class InputStore:
 
   def __init__(self, input_file):
     self.input_file = input_file
     self.data = None
 
-    # create directory if it doesn't exist
+    # create directory if it doesn't exist (skip for bare filenames like 'input.json')
     directory = os.path.dirname(input_file)
-    if not os.path.exists(directory):
-      os.makedirs(directory)
+    if directory:
+      try:
+        os.makedirs(directory, exist_ok=True)
+      except OSError as e:
+        raise InputStoreError(
+            f"Cannot create input-store directory '{directory}': {e}"
+        ) from e
 
     # create file if it doesn't exist
     if not os.path.exists(input_file):
-      with open(input_file, 'w') as f:
-        json.dump({}, f)
+      try:
+        with open(input_file, 'w') as f:
+          json.dump({}, f)
+      except OSError as e:
+        raise InputStoreError(
+            f"Cannot create input-store file '{input_file}': {e}"
+        ) from e
 
   def load(self):
-    with open(self.input_file, 'r') as f:
-      self.data = json.load(f)
+    try:
+      with open(self.input_file, 'r') as f:
+        self.data = json.load(f)
+    except OSError as e:
+      raise InputStoreError(
+          f"Cannot read input-store file '{self.input_file}': {e}"
+      ) from e
+    except json.JSONDecodeError as e:
+      raise InputStoreError(
+          f"Input-store file '{self.input_file}' contains invalid JSON: {e}"
+      ) from e
 
   def get_data(self):
     return self.data
@@ -32,5 +55,10 @@ class InputStore:
     self.data[key] = value
 
   def save(self):
-    with open(self.input_file, 'w') as f:
-      json.dump(self.data, f, indent=2)
+    try:
+      with open(self.input_file, 'w') as f:
+        json.dump(self.data, f, indent=2)
+    except OSError as e:
+      raise InputStoreError(
+          f"Cannot write input-store file '{self.input_file}': {e}"
+      ) from e

--- a/tests/test_commands_more.py
+++ b/tests/test_commands_more.py
@@ -10,6 +10,7 @@ from structkit.commands.list import ListCommand
 from structkit.commands.mcp import MCPCommand
 from structkit.commands.validate import ValidateCommand
 from structkit.file_item import ContentFetchError
+from structkit.input_store import InputStoreError
 from structkit.template_renderer import TemplateVariableError
 
 
@@ -413,3 +414,71 @@ def test_generate_remote_fetch_failure_exits_cleanly(parser, tmp_path, caplog):
     assert 'Failed to fetch content from' in caplog.text
     assert 'Traceback' not in caplog.text
     assert not (out_dir / 'out.txt').exists()
+
+
+# ---------------------------------------------------------------------------
+# InputStore tests
+# ---------------------------------------------------------------------------
+
+def test_input_store_relative_path_does_not_crash(tmp_path):
+    """A bare filename like 'input.json' must not cause makedirs('') crash."""
+    import os
+    from structkit.input_store import InputStore
+
+    orig = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        store = InputStore('input.json')
+        store.load()
+        assert store.get_data() == {}
+        store.set_value('key', 'value')
+        store.save()
+        store2 = InputStore('input.json')
+        store2.load()
+        assert store2.get_data() == {'key': 'value'}
+    finally:
+        os.chdir(orig)
+
+
+def test_generate_corrupt_input_store_exits_cleanly(parser, tmp_path, caplog):
+    """Corrupt JSON in the input-store exits 1 with a clean message and no Traceback."""
+    command = GenerateCommand(parser)
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+
+    # Write corrupt JSON
+    store_file = tmp_path / 'input.json'
+    store_file.write_text('{ not valid json')
+
+    struct_yaml = tmp_path / 'struct.yaml'
+    struct_yaml.write_text('files:\n  - hello.txt: Hello\n')
+
+    args = parser.parse_args(['--non-interactive', str(struct_yaml), str(out_dir)])
+    args.input_store = str(store_file)
+
+    with pytest.raises(SystemExit) as excinfo:
+        command.execute(args)
+
+    assert excinfo.value.code == 1
+    assert 'invalid JSON' in caplog.text
+    assert 'Traceback' not in caplog.text
+
+
+def test_generate_unreadable_input_store_exits_cleanly(parser, tmp_path, caplog):
+    """An OSError reading the input store exits 1 with a clean message and no Traceback."""
+    command = GenerateCommand(parser)
+    out_dir = tmp_path / 'out'
+    out_dir.mkdir()
+
+    struct_yaml = tmp_path / 'struct.yaml'
+    struct_yaml.write_text('files:\n  - hello.txt: Hello\n')
+
+    args = parser.parse_args(['--non-interactive', str(struct_yaml), str(out_dir)])
+    args.input_store = str(tmp_path / 'input.json')
+
+    with patch('builtins.open', side_effect=PermissionError('permission denied')):
+        with pytest.raises(SystemExit) as excinfo:
+            command.execute(args)
+
+    assert excinfo.value.code == 1
+    assert 'Traceback' not in caplog.text


### PR DESCRIPTION
## Summary

Fixes #166.

Using `--input-store input.json` (a bare filename with no directory component) caused `os.makedirs('')` to raise a `FileNotFoundError` before generation even started. Additionally, corrupt JSON or permission errors in the input-store file surfaced as raw Python tracebacks instead of user-friendly messages.

## Changes

### `structkit/input_store.py`
- Introduced `InputStoreError` — a clean domain exception for input-store failures.
- Fixed `InputStore.__init__`: `os.makedirs` is now only called when the directory component is non-empty, so bare filenames like `input.json` resolve to the current directory without crashing.
- Wrapped file-creation, `json.load`, and `json.dump` calls to convert `OSError` and `json.JSONDecodeError` into `InputStoreError` with a message that includes the file path.

### `structkit/commands/generate.py`
- Imported `InputStoreError` from `structkit.input_store`.
- `GenerateCommand.execute()` catches `InputStoreError` alongside `GenerateConfigError`, `TemplateVariableError`, and `ContentFetchError`, logging only the root-cause message and exiting with code 1.

### `tests/test_commands_more.py`
- Added `test_input_store_relative_path_does_not_crash`: verifies `InputStore('input.json')` creates and reads `./input.json` without error.
- Added `test_generate_corrupt_input_store_exits_cleanly`: verifies corrupt JSON exits 1 with a clean message and no `Traceback`.
- Added `test_generate_unreadable_input_store_exits_cleanly`: verifies an `OSError` reading the store exits 1 cleanly.

## Acceptance criteria

- [x] `--input-store input.json` works and creates/uses `./input.json`.
- [x] Corrupt input-store JSON exits 1 with a clean message and no `Traceback`.
- [x] Permission/read/write errors for the input store include the path and exit 1 cleanly.
- [x] Tests cover relative path, corrupt JSON, and read-error path.