### PR TITLE
docs: reference StructKit agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **StructKit** replaces copy-pasted boilerplate and aging "golden repos" with reusable YAML structures. It can render template variables, fetch canonical files from remote sources, preview changes before writing, and expose your scaffolds to AI assistants through the Model Context Protocol.
 
-> 🚀 **[Quick Start](docs/quickstart.md)** | 📚 **[Docs](docs/index.md)** | 🧩 **[Examples](examples/)** | 🤖 **[MCP / AI Agent Guide](docs/mcp-integration.md)** | 💬 **[Discussions](https://github.com/httpdss/structkit/discussions)**
+> 🚀 **[Quick Start](docs/quickstart.md)** | 📚 **[Docs](docs/index.md)** | 🧩 **[Examples](examples/)** | 🤖 **[MCP / AI Agent Guide](docs/mcp-integration.md)** | 🧠 **[Agent Skills](docs/agent-skills.md)** | 💬 **[Discussions](https://github.com/httpdss/structkit/discussions)**
 
 ## ⚡ Try it in 60 seconds
 
@@ -58,6 +58,7 @@ Project scaffolding tools exist in most ecosystems, but StructKit solves problem
 
 - **Remote-first content:** Reference your organization's canonical CI template from GitHub directly in your StructKit config. When the template updates, all new projects get the update — no copy-paste maintenance.
 - **AI-native via MCP:** Start the StructKit MCP server so your AI assistant can generate project scaffolds from natural language using your templates as the source of truth.
+- **Agent skill ready:** Install the companion [`httpdss/structkit-skills`](https://github.com/httpdss/structkit-skills) workflow skill so AI assistants consistently inspect, preview, generate, and validate StructKit structures.
 - **YAML-first:** Define structures directly in YAML. No separate template repository is required.
 - **Safe by default:** Use dry-run previews and file conflict strategies before writing into existing projects.
 
@@ -137,6 +138,7 @@ Our comprehensive documentation is organized into the following sections:
 - **[Mappings](docs/mappings.md)** - External data integration
 - **[GitHub Integration](docs/github-integration.md)** - Automation with GitHub Actions
 - **[MCP / AI Agent Workflow](docs/mcp-integration.md)** - Model Context Protocol for approved-template scaffolding with AI assistants
+- **[Agent Skills](docs/agent-skills.md)** - Installable StructKit workflow skill for AI assistants
 - **[Command-Line Completion](docs/completion.md)** - Enhanced CLI experience
 
 ### 👩‍💻 Development

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,0 +1,40 @@
+# Agent Skills
+
+StructKit is designed to be used directly by AI assistants through MCP and other tool integrations. For teams that use reusable agent skills, the companion [`httpdss/structkit-skills`](https://github.com/httpdss/structkit-skills) repository provides an installable workflow skill that teaches assistants how to use StructKit safely.
+
+## StructKit workflow skill
+
+The [`structkit-workflows`](https://github.com/httpdss/structkit-skills) skill covers the recommended agent workflow for StructKit:
+
+1. Discover available structures.
+2. Inspect the selected structure and its variables.
+3. Preview or dry-run the generation before writing files.
+4. Use conservative file-conflict behavior for existing repositories.
+5. Validate `.struct.yaml` files and generated output.
+
+This is useful when you want an assistant to scaffold from approved StructKit templates instead of inventing project structure from scratch.
+
+## Install
+
+With Skills-compatible installers:
+
+```bash
+npx skills add httpdss/structkit-skills
+```
+
+With Hermes Agent:
+
+```bash
+hermes skills install https://raw.githubusercontent.com/httpdss/structkit-skills/main/SKILL.md --name structkit-workflows
+```
+
+## When to use it
+
+Use the skill when an agent needs to:
+
+- Generate a project, Terraform module, CI baseline, documentation bundle, or application scaffold with StructKit.
+- Author or update reusable `.struct.yaml` structures.
+- Review a StructKit generation plan before files are written.
+- Package StructKit-backed workflows for repeatable use across repositories.
+
+For lower-level tool integration, see the [MCP / AI Agent Workflow](mcp-integration.md) guide.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Welcome to the comprehensive documentation for StructKit - the Automated Project
 - [Mappings](mappings.md) - Using external data mappings
 - [GitHub Integration](github-integration.md) - Automation with GitHub Actions
 - [MCP / AI Agent Workflow](mcp-integration.md) - Model Context Protocol for approved-template scaffolding with AI assistants
+- [Agent Skills](agent-skills.md) - Installable StructKit workflow skill for AI assistants
 
 ### Development
 
@@ -38,6 +39,7 @@ Welcome to the comprehensive documentation for StructKit - the Automated Project
 ## 🔗 External Resources
 
 - [GitHub Repository](https://github.com/httpdss/struct)
+- [StructKit Agent Skills](https://github.com/httpdss/structkit-skills)
 - [Articles and Tutorials](articles.md)
 - [Known Issues](known-issues.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,8 @@ nav:
     - Custom Structures: structures.md
     - Hooks: hooks.md
     - GitHub Integration: github-integration.md
+    - MCP / AI Agent Workflow: mcp-integration.md
+    - Agent Skills: agent-skills.md
     - Schema Reference: schema.md
   - Development:
     - Development Setup: development.md


### PR DESCRIPTION
## Summary

- add README references to the companion `httpdss/structkit-skills` repository
- add a new `docs/agent-skills.md` page with install/use guidance for the StructKit workflow skill
- add the new Agent Skills page, plus existing MCP guide, to MkDocs navigation

## Verification

- `git diff --check`
- ad-hoc Markdown link check for touched docs
- `uvx --with 'mkdocs-material[imaging]' --with mkdocs-git-revision-date-localized-plugin mkdocs build`

Note: strict MkDocs build still fails on pre-existing docs warnings for blog/example links and unlisted pages; non-strict build succeeds.