### PR TITLE
docs: standardize StructKit naming

### DIFF
--- a/.github/instructions/struct.instructions.md
+++ b/.github/instructions/struct.instructions.md
@@ -6,7 +6,7 @@ applyTo: '**'
 
 ## Role
 
-You are an expert assistant that generates valid `.struct.yaml` files for the [StructKit tool](https://github.com/httpdss/struct), which automates project structure generation from YAML configuration.
+You are an expert assistant that generates valid `.struct.yaml` files for the [StructKit tool](https://github.com/httpdss/structkit), which automates project structure generation from YAML configuration.
 
 ## Defining the `.struct.yaml` file
 

--- a/.github/prompts/struct.prompt.md
+++ b/.github/prompts/struct.prompt.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-You are an expert assistant that generates valid `.struct.yaml` files for the [StructKit tool](https://github.com/httpdss/struct), which automates project structure generation from YAML configuration.
+You are an expert assistant that generates valid `.struct.yaml` files for the [StructKit tool](https://github.com/httpdss/structkit), which automates project structure generation from YAML configuration.
 
 ## Defining the `.struct.yaml` file
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,10 +1,10 @@
 # CLI Reference
 
-This document provides a reference for the `struct` command-line interface (CLI).
+This document provides a reference for the `structkit` command-line interface (CLI).
 
 ## Overview
 
-The `struct` CLI allows you to generate project structures from YAML configuration files. It supports both built-in structure definitions and custom structures.
+The `structkit` CLI allows you to generate project structures from YAML configuration files. It supports both built-in structure definitions and custom structures.
 
 **Basic Usage:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Welcome to the comprehensive documentation for StructKit - the Automated Project
 
 ## 🔗 External Resources
 
-- [GitHub Repository](https://github.com/httpdss/struct)
+- [GitHub Repository](https://github.com/httpdss/structkit)
 - [StructKit Agent Skills](https://github.com/httpdss/structkit-skills)
 - [Articles and Tutorials](articles.md)
 - [Known Issues](known-issues.md)


### PR DESCRIPTION
## Summary

- update CLI reference wording to consistently call the command-line tool `structkit`
- fix stale `httpdss/struct` repository links to `httpdss/structkit`
- update GitHub prompt/instruction references to the canonical StructKit repository URL

## Verification

- Ad-hoc verification script under `/tmp/hermes-verify-structkit-naming-*` checked changed docs/prompts, local Markdown links, canonical GitHub URL reachability, and `git diff --check`
- `uvx --with 'mkdocs-material[imaging]' --with mkdocs-git-revision-date-localized-plugin mkdocs build`

Note: MkDocs build succeeds, with pre-existing warnings for unrelated blog/example links.