### PR TITLE
Fix release drafter warnings and sync pyproject version

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,6 +1,9 @@
 name: publish-pypi
 
 on:
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       upload:
@@ -22,19 +25,33 @@ jobs:
 
       - name: Check package version
         run: |
-          # Ensure the version in pyproject.toml is equivalent to the latest git tag
+          set -euo pipefail
+
+          # Ensure the version in pyproject.toml matches the release tag being
+          # published. For manual runs, fall back to the latest published
+          # release tag.
           # Read version from pyproject.toml
           PACKAGE_VERSION=$(python -c "import tomllib; f = open('pyproject.toml', 'rb'); data = tomllib.load(f); f.close(); print(data['project']['version'])")
           echo "Package version: $PACKAGE_VERSION"
 
-          # Go to github releases to get latest tag
-          LATEST_TAG=$(curl -s https://api.github.com/repos/httpdss/structkit/releases/latest | grep 'tag_name' | cut -d\" -f4)
-          # Remove leading 'v' if present
-          LATEST_TAG=${LATEST_TAG#v}
-          echo "Latest tag: $LATEST_TAG"
+          if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            RELEASE_TAG="${GITHUB_REF_NAME}"
+          else
+            RELEASE_TAG=$(python - <<'PY'
+          import json
+          import urllib.request
 
-          if [ "$PACKAGE_VERSION" != "$LATEST_TAG" ]; then
-            echo "Error: Package version ($PACKAGE_VERSION) does not match latest git tag ($LATEST_TAG)"
+          with urllib.request.urlopen("https://api.github.com/repos/httpdss/structkit/releases/latest") as response:
+              print(json.load(response)["tag_name"])
+          PY
+          )
+          fi
+
+          RELEASE_VERSION=${RELEASE_TAG#v}
+          echo "Release version: $RELEASE_VERSION"
+
+          if [ "$PACKAGE_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Error: Package version ($PACKAGE_VERSION) does not match release version ($RELEASE_VERSION)"
             exit 1
           fi
 

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: release-drafter/release-drafter@v6.1.0
+      - uses: release-drafter/release-drafter@v7.5.1
         id: release-drafter
         with:
           config-name: release-drafter.yml
@@ -24,3 +24,42 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sync pyproject version to release draft
+        env:
+          RESOLVED_VERSION: ${{ steps.release-drafter.outputs.resolved_version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RESOLVED_VERSION}" ]; then
+            echo "Release Drafter did not resolve a version"
+            exit 1
+          fi
+
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["RESOLVED_VERSION"].removeprefix("v")
+          path = Path("pyproject.toml")
+          text = path.read_text()
+          updated, count = re.subn(
+              r'(?m)^(version\s*=\s*")[^"]+(")$',
+              rf'\g<1>{version}\2',
+              text,
+              count=1,
+          )
+          if count == 0:
+              raise SystemExit("pyproject.toml version field was not found")
+          path.write_text(updated)
+          PY
+
+          if git diff --quiet -- pyproject.toml; then
+            echo "pyproject.toml already matches ${RESOLVED_VERSION}"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump pyproject version to ${RESOLVED_VERSION}"
+          git push


### PR DESCRIPTION
## Summary

- Updates Release Drafter from `v6.1.0` to `v7.5.1`, which uses Node 24 and avoids the Node 20 deprecation warning from the linked run.
- Adds a Release Drafter follow-up step that syncs `pyproject.toml` to `steps.release-drafter.outputs.resolved_version` and commits the bump back to `main` when needed.
- Adds `release.published` as a trigger for the PyPI workflow, and changes its version guard to compare `pyproject.toml` against the release tag being published instead of always using the latest release API result.

## Verification

- `actionlint .github/workflows/release-drafter.yaml .github/workflows/publish-pypi.yml` → passed
- YAML parse check for both changed workflows → passed
- Ad-hoc `/tmp/hermes-verify-release-workflows.py` → passed: release-drafter action version, pyproject sync commit/no-op behavior, and publish version check match/reject behavior
- `git diff --check` → passed