### PR TITLE
Fix github file fetching with variables

### DIFF
--- a/structkit/file_item.py
+++ b/structkit/file_item.py
@@ -104,6 +104,8 @@ class FileItem:
       }
       if not template_vars:
         return default_vars
+      if not isinstance(template_vars, dict):
+        return default_vars
       return {**default_vars, **template_vars}
 
     def apply_template_variables(self, template_vars):

--- a/tests/test_file_item.py
+++ b/tests/test_file_item.py
@@ -56,3 +56,32 @@ def test_fetch_content_renders_template(monkeypatch):
     assert file_item.content == "Hello, World!"
     assert rendered["content"] == "Hello, {{@ name @}}!"
     assert rendered["vars"]["name"] == "World"
+
+
+def test_fetch_content_with_config_variables_list(monkeypatch, tmp_path):
+    properties = {
+        "name": ".gitignore",
+        "file": "github://github/gitignore/main/Python.gitignore",
+        "config_variables": [
+            {
+                "project_name": {
+                    "description": "Name of your project",
+                    "type": "string",
+                    "default": "MyProject",
+                }
+            }
+        ],
+        "input_store": str(tmp_path / "input.json"),
+        "non_interactive": True,
+    }
+    file_item = FileItem(properties)
+
+    monkeypatch.setattr(
+        file_item.content_fetcher,
+        "fetch_content",
+        lambda location: "# Python gitignore\n*.pyc\n",
+    )
+
+    file_item.fetch_content()
+
+    assert file_item.content == "# Python gitignore\n*.pyc"


### PR DESCRIPTION
## Summary
- Fix remote file fetching when `config_variables` is a YAML variables list instead of a template vars mapping
- Add a regression test for fetching a `github://` file from a structure that declares variables

Fixes #183

## Verification
- `pytest tests/test_file_item.py tests/test_content_fetcher_more.py` — 22 passed
- CLI reproduction from issue with `github://github/gitignore/main/Python.gitignore` and variables — generated `.gitignore` successfully
- `pytest` — 213 passed
- `git diff --check` — passed